### PR TITLE
Capture everything from the log

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ const logger = require('./lib/logger');
 
 (function(){
     var oldLog = console.log;
-    console.log = function (string) {
-      logger.log(string)
-      oldLog.apply(console, arguments);
+    console.log = function () {
+      logger.log(arguments)
+      oldLog.apply(console, arguments)
     };
 })();

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -25,8 +25,8 @@ class Logger {
     })
   }
 
-  log(string) {
-    this.pusher.trigger(process.env.PUSHER_LOG_CHANNEL, 'log-event', { kind: 'app', line: string, timestamp: new Date })
+  log(data) {
+    this.pusher.trigger(process.env.PUSHER_LOG_CHANNEL, 'log-event', { kind: 'app', timestamp: new Date, data: data })
   }
 }
 


### PR DESCRIPTION
This does two things...
1. Pass all arguments to console.log
2. Use `data` instead of `line` because people could be logging anything.

I'm not thrilled about the var name data – content or object are other options.