### PR TITLE
Separate the info level from log

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,9 +4,17 @@ const logger = require('./lib/logger');
 (function(){
     var oldLog = console.log;
     console.log = function () {
-      logger.info(arguments)
+      logger.log(arguments)
       if (!process.env.NOODLE_ENV) {
         oldLog.apply(console, arguments)
+      }
+    };
+
+    var oldInfo = console.info;
+    console.info = function () {
+      logger.info(arguments)
+      if (!process.env.NOODLE_ENV) {
+        oldInfo.apply(console, arguments)
       }
     };
 

--- a/lib/logger.js
+++ b/lib/logger.js
@@ -3,19 +3,23 @@ const request = require('request')
 
 class Logger {
 
+  log(args) {
+    this.sendLog('log', args)
+  }
+
   info(args) {
-    this.log('info', args)
+    this.sendLog('info', args)
   }
 
   warn(args) {
-    this.log('warn', args)
+    this.sendLog('warn', args)
   }
 
   error(args) {
-    this.log('error', args)
+    this.sendLog('error', args)
   }
 
-  log(level, args) {
+  sendLog(level, args) {
     if (!process.env.LOG_CHANNEL) {
       return
     }


### PR DESCRIPTION
Differentiate `log` entries from `info` entries like the JS console does.